### PR TITLE
Add ability to customize pyenv-win-venv installation location

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Adding the following paths to your USER PATH variable in order to access the pye
 [System.Environment]::SetEnvironmentVariable('path', $env:USERPROFILE + "\.pyenv-win-venv\bin;"  + [System.Environment]::GetEnvironmentVariable('path', "User"),"User")
 ```
 
-> [!NOTES] <br/>
-> If you use another path other than `$HOME`, then add the project's `bin` folder to your corresponding USER PATH variable. <br/>
+- **NOTES**: If you use another path other than `$HOME`, then add the project's `bin` folder to your corresponding USER PATH variable.
 
 - For example, your `pyenv-win-venv` folder located in `D:\Applications\pyenv-win-venv`
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This script depends on the [pyenv-win](https://github.com/pyenv-win/pyenv-win) s
 
 ## Power Shell
 
-```
+```pwsh
 Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win-venv/main/bin/install-pyenv-win-venv.ps1" -OutFile "$HOME\install-pyenv-win-venv.ps1";
 &"$HOME\install-pyenv-win-venv.ps1"
 ```
@@ -22,7 +22,7 @@ Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv
 
 ## Git
 
-```
+```pwsh
 git clone https://github.com/pyenv-win/pyenv-win-venv "$HOME\.pyenv-win-venv"
 ```
 
@@ -36,6 +36,15 @@ Adding the following paths to your USER PATH variable in order to access the pye
 [System.Environment]::SetEnvironmentVariable('path', $env:USERPROFILE + "\.pyenv-win-venv\bin;"  + [System.Environment]::GetEnvironmentVariable('path', "User"),"User")
 ```
 
+> [!NOTES] <br/>
+> If you use another path other than `$HOME`, then add the project's `bin` folder to your corresponding USER PATH variable. <br/>
+
+- For example, your `pyenv-win-venv` folder located in `D:\Applications\pyenv-win-venv`
+
+  ```pwsh
+  [System.Environment]::SetEnvironmentVariable('path', "D:\Applications\pyenv-win-venv\bin;" + [System.Environment]::GetEnvironmentVariable('path', "User"), "User")
+  ```
+
 # Update
 
 Automatically using `pyenv-venv update self` (Recommended)
@@ -48,7 +57,7 @@ Go to `%USERPROFILE%\.pyenv-win-venv` (which is your installed path) and run `gi
 
 ## Power Shell (If the CLI was installed using the PowerScript Installation Script)
 
-```
+```pwsh
 Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win-venv/main/bin/install-pyenv-win-venv.ps1" -OutFile "$HOME\install-pyenv-win-venv.ps1"; &"$HOME\install-pyenv-win-venv.ps1"
 ```
 
@@ -62,7 +71,7 @@ pyenv-venv uninstall self
 
 ## Power Shell
 
-```
+```pwsh
 Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win-venv/main/bin/install-pyenv-win-venv.ps1" -OutFile "$HOME\install-pyenv-win-venv.ps1";
 &"$HOME\install-pyenv-win-venv.ps1" -Uninstall
 ```
@@ -83,12 +92,14 @@ Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv
                         current directory and activate the env
     activate            activate an env
     deactivate          deactivate an env
+    completion          autocomplete script for powershell
     install             install an env
     uninstall           uninstall an env
     uninstall self      uninstall the CLI and its envs
     list <command>      list all installed envs/python versions
     local               set the given env in .python-version file
     config              show the app directory
+
     update self         update the CLI to the latest version
     which <command>     show the full path to an executable
     help <command>      show the CLI/<command> menu
@@ -167,6 +178,37 @@ pyenv-venv which <exec_name>
 pyenv-venv help install
 ```
 
+## PowerShell Completion
+
+- To load completion code into current shell:
+
+```pwsh
+pyenv-venv completion | Out-String | Invoke-Expression
+```
+
+- To add completion code directly to the `$PROFILE`
+
+```pwsh
+pyenv-venv completion >> $PROFILE
+```
+
+- One-time execution of `pyenv-venv` completion code to the `$PROFILE`
+
+```pwsh
+Add-Content $PROFILE "if (Get-Command pyenv-venv -ErrorAction SilentlyContinue) {
+    pyenv-venv completion | Out-String | Invoke-Expression
+}"
+```
+
+- You can also save the completion script and execute it in the `$PROFILE`, for example:
+
+```pwsh
+# Create completion script
+pyenv-venv completion > "$HOME\pyenv-venv-completion.ps1"
+# Add to the `$PROFILE`
+Add-Content $PROFILE "$HOME\pyenv-venv-completion.ps1"
+```
+
 # Note
 
 ## Env automatic activation using `.python-version` file
@@ -184,7 +226,7 @@ pyenv-venv help install
 
   - First check if you already have a powershell profile.
 
-    ```
+    ```pwsh
     Test-Path $profile
     ```
 
@@ -192,7 +234,7 @@ pyenv-venv help install
 
   - Create a new profile using:
 
-    ```
+    ```pwsh
     New-Item -path $profile -type file –force
     ```
 

--- a/bin/install-pyenv-win-venv.ps1
+++ b/bin/install-pyenv-win-venv.ps1
@@ -1,3 +1,4 @@
+# cSpell: disable
 <#
     .SYNOPSIS
     Installs pyenv-win-venv
@@ -25,8 +26,15 @@
 param (
     [Switch] $Uninstall = $False
 )
-    
-$PyEnvWinVenvDir = "${env:USERPROFILE}\.pyenv-win-venv"
+
+$chooseLocation = $(Write-Host "Install 'pyenv-win-venv' to default (y) or custom (n) location?" -NoNewLine; Read-Host)
+if ($chooseLocation.ToUpper() -eq 'Y') {
+    $PyEnvWinVenvDir = "${env:USERPROFILE}\.pyenv-win-venv"
+}
+else {
+    $PyEnvWinVenvDir = Read-Host "Input your desired location for pyenv-win-venv installation"
+}
+
 $BinPath = "${PyEnvWinVenvDir}\bin"
     
 Function Remove-PyEnvVenvVars() {
@@ -75,7 +83,7 @@ Function Get-LatestVersion() {
 }
 
 Function Main() {
-    Remove-Item "$HOME\install-pyenv-win-venv.ps1"
+    Remove-Item "$HOME\install-pyenv-win-venv.ps1" -ErrorAction SilentlyContinue
     If ($Uninstall) {
         Remove-PyEnvWinVenv
         If ($LastExitCode -eq 0) {
@@ -121,7 +129,7 @@ Function Main() {
     else {
         # First installation,
         # Add the \bin path to the User's Environment Variables
-        [System.Environment]::SetEnvironmentVariable('path', $env:USERPROFILE + "\.pyenv-win-venv\bin;" + [System.Environment]::GetEnvironmentVariable('path', "User"), "User")
+        [System.Environment]::SetEnvironmentVariable('path', "$PyEnvWinVenvDir\bin;" + [System.Environment]::GetEnvironmentVariable('path', "User"), "User")
     }
 
     (New-Item -Path $PyEnvWinVenvDir -ItemType Directory)  *> $null

--- a/bin/pyenv-venv.bat
+++ b/bin/pyenv-venv.bat
@@ -1,3 +1,8 @@
 @ECHO OFF
 @REM Alias for pyenv-win-venv.bat
-"%USERPROFILE%\.pyenv-win-venv\bin\pyenv-win-venv.bat" %*
+
+@REM "%USERPROFILE%\.pyenv-win-venv\bin\pyenv-win-venv.bat" %*
+
+SET ScriptDir=%~dp0
+SET ScriptDir=%ScriptDir:~0,-1%
+"%ScriptDir%\pyenv-win-venv.bat" %*

--- a/bin/pyenv-venv.ps1
+++ b/bin/pyenv-venv.ps1
@@ -1,2 +1,2 @@
 # Alias for pyenv-win-venv.ps1
-&"$HOME\.pyenv-win-venv\bin\pyenv-win-venv.ps1" @args
+&"$PSScriptRoot\pyenv-win-venv.ps1" @args

--- a/bin/pyenv-win-venv.bat
+++ b/bin/pyenv-win-venv.bat
@@ -1,2 +1,8 @@
 @ECHO OFF
-powershell -File "%USERPROFILE%\.pyenv-win-venv\bin\pyenv-win-venv.ps1" %*
+@REM Determine script location for Windows Batch File
+
+@REM Get current folder with no trailing slash
+SET ScriptDir=%~dp0
+SET ScriptDir=%ScriptDir:~0,-1%
+
+powershell -File "%ScriptDir%\pyenv-win-venv.ps1" %*

--- a/bin/pyenv-win-venv.ps1
+++ b/bin/pyenv-win-venv.ps1
@@ -22,11 +22,12 @@ Param(
 # Auto-detect the shell
 if ($MyInvocation.MyCommand.CommandType -eq "ExternalScript") {
     $invokedShell = "bat"
-} else {
+}
+else {
     $invokedShell = "ps1"
 }
 
-$app_dir = "$HOME\.pyenv-win-venv"
+$app_dir = Resolve-Path "$PSScriptRoot" | Split-Path
 $app_env_dir = "$app_dir\envs"
 $cli_version = Get-Content "$app_dir\.version"
 
@@ -247,7 +248,8 @@ function  main {
         }
     }
     else { 
-        Write-Host "Command is not valid. Run `"pyenv-win-venv help`" for the HelpMenu" }
+        Write-Host "Command is not valid. Run `"pyenv-win-venv help`" for the HelpMenu" 
+    }
 }
 
 
@@ -328,7 +330,7 @@ Function Remove-PyEnvVenvVars() {
 Function Remove-PyEnvVenvProfile() {
     $CurrentProfile = Get-Content $Profile
     $UpdatedProfile = $CurrentProfile.Replace("pyenv-venv init", "")
-    Set-Content -Path  $Profile -Value $UpdatedProfile
+    Set-Content -Path $Profile -Value $UpdatedProfile
 }
 
 # Function to write debug log

--- a/bin/pyenv-win-venv.ps1
+++ b/bin/pyenv-win-venv.ps1
@@ -223,6 +223,9 @@ function  main {
             pyenv which $subcommand2
         }
     }
+    elseif ($subcommand1 -eq 'completion') {
+        Get-Content "$app_dir\completions\pyenv-win-venv.ps1"
+    }
     elseif ($subcommand1 -eq "help" -Or !$subcommand1) {
         if (!$subcommand2) {
             # Show the help menu if help command used or no commands are used
@@ -233,6 +236,9 @@ function  main {
         }
         elseif ($subcommand2 -eq "activate") {
             HelpActivate
+        }
+        elseif ($subcommand2 -eq "completion") {
+            HelpCompletion
         }
         elseif ($subcommand2 -eq "install") {
             HelpInstall
@@ -266,6 +272,7 @@ init                search for .python-version file in the
                     current directory and activate the env
 activate            activate an env
 deactivate          deactivate an env
+completion          autocomplete script for powershell
 install             install an env
 uninstall           uninstall an env
 uninstall self      uninstall the CLI and its envs
@@ -407,6 +414,28 @@ exec_name   name of the executable
 
 Example: `pyenv-venv which python`
 "
+}
+
+Function HelpCompletion() {
+    Write-Host 'Usage: pyenv-venv completion
+
+Generate autocompletion script for powershell.
+
+- Load completion code into current shell:
+pyenv-venv completion | Out-String | Invoke-Expression
+
+- Add completion code directly to $PROFILE:
+pyenv-venv completion >> $PROFILE
+
+- Execute completion code in the $PROFILE:
+Add-Content $PROFILE "if (Get-Command pyenv-venv -ErrorAction SilentlyContinue) {
+    pyenv-venv completion | Out-String | Invoke-Expression
+}"
+
+- Save completion script and execute in the $PROFILE:
+pyenv-venv completion > "$HOME\pyenv-venv-completion.ps1"
+Add-Content $PROFILE "$HOME\pyenv-venv-completion.ps1"
+'
 }
 
 main

--- a/completions/pyenv-win-venv.ps1
+++ b/completions/pyenv-win-venv.ps1
@@ -1,0 +1,45 @@
+# cSpell: disable
+# pyenv-win-venv completion start
+$script:PyenvVenvCommands = @(
+    'activate',  
+    'deactivate', 
+    'init', 
+    'install',
+    'config',
+    'completion',
+    'list envs', 
+    'list python', 
+    'local', 
+    'uninstall self', 
+    'uninstall', 
+    'update self', 
+    'which',
+    'help'
+)
+function script:PyenvVenvExpandCmd($filter) {
+    $cmdList = @()
+    $cmdList += $PyenvVenvCommands
+    $cmdList -like "$filter*"
+}
+
+function script:PyenvVenvTabExpansion($lastBlock) {
+    switch -regex ($lastBlock) {
+        "^(?<cmd>\S*)$" {
+            return PyenvVenvExpandCmd $matches['cmd'] $true
+        }
+    }
+}
+
+$scriptBlock = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $rest = $commandAst.CommandElements[1..$commandAst.CommandElements.Count] -join ' '
+    if ($rest -ne "" -and $wordToComplete -eq "") {
+        $rest += " "
+    }
+    PyenvVenvTabExpansion $rest
+}
+
+@('pyenv-venv', 'pyenv-win-venv') | ForEach-Object {
+    Register-ArgumentCompleter -Native -CommandName $_ -ScriptBlock $scriptBlock
+}
+# pyenv-win-venv completion end

--- a/completions/pyenv-win-venv.ps1
+++ b/completions/pyenv-win-venv.ps1
@@ -2,6 +2,8 @@
 # This script is based on https://github.com/Moeologist/scoop-completion
 
 # powershell completion for pyenv-win-venv
+
+###-start-pyenv-venv-completion-###
 $script:PyenvVenvCommands = @(
     'activate',
     'deactivate',
@@ -84,6 +86,6 @@ $scriptBlock = {
     PyenvVenvTabExpansion $rest
 }
 
-@('pyenv-venv', 'pyenv-win-venv') | ForEach-Object {
-    Register-ArgumentCompleter -Native -CommandName $_ -ScriptBlock $scriptBlock
-}
+Register-ArgumentCompleter -Native -CommandName @('pyenv-venv', 'pyenv-win-venv') -ScriptBlock $scriptBlock
+
+###-end-pyenv-venv-completion-###


### PR DESCRIPTION
Instead of using the default location at `$env:USERPROFILE\.pyenv-win-venv`, we can now use pyenv-win-venv from different location. For example: D:\tools\pyenv-win-venv.

## Summary by Sourcery

Introduce the ability to customize the installation location of pyenv-win-venv, providing users with the flexibility to choose a directory other than the default. Enhance the script by improving error handling during the removal of installation scripts.

New Features:
- Add option to customize the installation location of pyenv-win-venv, allowing users to specify a directory other than the default.

Enhancements:
- Improve error handling by adding -ErrorAction SilentlyContinue to the Remove-Item command.