### PR TITLE
Replace inference of shell with explicit parameter detection

### DIFF
--- a/bin/pyenv-win-venv.bat
+++ b/bin/pyenv-win-venv.bat
@@ -5,4 +5,4 @@
 SET ScriptDir=%~dp0
 SET ScriptDir=%ScriptDir:~0,-1%
 
-powershell -File "%ScriptDir%\pyenv-win-venv.ps1" %*
+powershell -File "%ScriptDir%\pyenv-win-venv.ps1" -CalledFromCMD %*

--- a/bin/pyenv-win-venv.ps1
+++ b/bin/pyenv-win-venv.ps1
@@ -14,18 +14,20 @@
 
 Param(
     [switch]$debug,
+    [switch]$CalledFromCMD,
     $subcommand1, 
     $subcommand2, 
     $subcommand3
 )
 
-# Auto-detect the shell
-if ($MyInvocation.MyCommand.CommandType -eq "ExternalScript") {
+# Detect the shell via input parameter
+if ($CalledFromCMD) {
     $invokedShell = "bat"
 }
 else {
     $invokedShell = "ps1"
 }
+Write-Debug-Log "Detected Shell: $invokedShell"
 
 $app_dir = Resolve-Path "$PSScriptRoot" | Split-Path
 $app_env_dir = "$app_dir\envs"


### PR DESCRIPTION
When calling pyenv-win-venv using the pyenv-venv invocation, the CommandType is mapped to an "ExternalScript", which then makes the activation of a virtualenv create a CMD shell, even if initially called from powershell.

This removes that inference in favour of an explicit call parameter which is set to True only when the .bat file is called, which should (only) be whenever pyenv-win-venv is invoked from a CMD shell.

## Summary by Sourcery

Bug Fixes:
- Fix an issue where virtual environments were always activated in CMD shell, even when invoked from PowerShell.